### PR TITLE
Zookeeper harvests information in all nodes

### DIFF
--- a/zk.go
+++ b/zk.go
@@ -40,6 +40,13 @@ func visitZK(path string, fn reap) {
 		return
 	} else {
 		log.WithFields(log.Fields{"func": "visitZK"}).Debug(fmt.Sprintf("%s has %d children", path, len(children)))
+
+		if val, _, err := zkconn.Get(path); err != nil {
+			log.WithFields(log.Fields{"func": "visitZK"}).Error(fmt.Sprintf("%s", err))
+		} else {
+			fn(path, string(val))
+		}
+
 		if len(children) > 0 { // there are children
 			for _, c := range children {
 				newpath := ""
@@ -50,12 +57,6 @@ func visitZK(path string, fn reap) {
 				}
 				log.WithFields(log.Fields{"func": "visitZK"}).Debug(fmt.Sprintf("Next visiting child %s", newpath))
 				visitZK(newpath, fn)
-			}
-		} else { // we're on a leaf node
-			if val, _, err := zkconn.Get(path); err != nil {
-				log.WithFields(log.Fields{"func": "visitZK"}).Error(fmt.Sprintf("%s", err))
-			} else {
-				fn(path, string(val))
 			}
 		}
 	}


### PR DESCRIPTION
Formerly Burry would only harvest ZK data from leaf nodes. As discussed in Issue #7 this was a problem when trying to get a ZK backup for Kafka, which stores its topic shard mapping data in some of the parent nodes. This change lets Burry harvest all the data.

I tested this with the same set up outlined in Issue #7 and it worked fine, but if you have a test suite you would like me to test against, let me know.

Also, sorry for taking ages on getting this change done, the last couple of months turned out to be unexpectedly busy for me. :)