### PR TITLE
Change naming scheme to bucket/snapshotid

### DIFF
--- a/remotes.go
+++ b/remotes.go
@@ -33,8 +33,8 @@ func toremoteS3(localarch string) {
 	accessKeyID, secretAccessKey := extractS3cred()
 	useSSL := true
 	_, f := filepath.Split(localarch)
-	bucket := brf.InfraService + "-backup-" + strings.TrimSuffix(f, filepath.Ext(f))
-	object := REMOTE_ARCH_FILE
+	bucket := brf.InfraService + "-backup"
+	object := strings.TrimSuffix(f, filepath.Ext(f))
 
 	log.WithFields(log.Fields{"func": "toremoteS3"}).Debug(fmt.Sprintf("Trying to back up to %s/%s in S3 compatible remote storage", bucket, object))
 	if mc, err := minio.New(endpoint, accessKeyID, secretAccessKey, useSSL); err != nil {
@@ -81,8 +81,8 @@ func fromremoteS3() string {
 	endpoint := brf.Creds.StorageTargetEndpoint
 	accessKeyID, secretAccessKey := extractS3cred()
 	useSSL := true
-	bucket := brf.InfraService + "-backup-" + snapshotid
-	object := "latest.zip"
+	bucket := brf.InfraService + "-backup"
+	object := snapshotid
 
 	log.WithFields(log.Fields{"func": "fromremoteS3"}).Debug(fmt.Sprintf("Trying to retrieve %s/%s from S3 compatible remote storage", bucket, object))
 	if mc, err := minio.New(endpoint, accessKeyID, secretAccessKey, useSSL); err != nil {


### PR DESCRIPTION
Hello there!

This commit changes the naming scheme from `ISVC-BACKUP-SNAPSHOTID/ZIPFILE` to `ISVC-BACKUP/SNAPSHOTID`

Keeping all snapshot in one bucket simplifies the deletion of old backups and maintenance of bucket policies. Both operation where tested against minio and consul as ISVC.

Thanks!