### PR TITLE
Allow to configure the infra timeout via flag

### DIFF
--- a/etcd.go
+++ b/etcd.go
@@ -21,7 +21,7 @@ func backupETCD() bool {
 	cfg := etcd.Config{
 		Endpoints:               []string{"http://" + brf.Endpoint},
 		Transport:               etcd.DefaultTransport,
-		HeaderTimeoutPerRequest: time.Second,
+		HeaderTimeoutPerRequest: time.Duration(brf.Timeout) * time.Second,
 	}
 	c, _ := etcd.New(cfg)
 	kapi = etcd.NewKeysAPI(c)
@@ -74,7 +74,7 @@ func restoreETCD() bool {
 		cfg := etcd.Config{
 			Endpoints:               []string{"http://" + brf.Endpoint},
 			Transport:               etcd.DefaultTransport,
-			HeaderTimeoutPerRequest: time.Second,
+			HeaderTimeoutPerRequest: time.Duration(brf.Timeout) * time.Second,
 		}
 		c, _ := etcd.New(cfg)
 		kapi = etcd.NewKeysAPI(c)

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ var (
 	isvcs = [...]string{INFRA_SERVICE_ZK, INFRA_SERVICE_ETCD, INFRA_SERVICE_CONSUL}
 	// the infra service endpoint to use:
 	endpoint string
+  timeout  int
 	zkconn   *zk.Conn
 	kapi     etcd.KeysAPI
 	ckv      *consul.KV
@@ -77,6 +78,7 @@ func init() {
 	flag.StringVarP(&bop, "operation", "o", BURRY_OPERATION_BACKUP, fmt.Sprintf("The operation to carry out.\n\tSupported values are %v", bops))
 	flag.StringVarP(&isvc, "isvc", "i", INFRA_SERVICE_ZK, fmt.Sprintf("The type of infra service to back up or restore.\n\tSupported values are %v", isvcs))
 	flag.StringVarP(&endpoint, "endpoint", "e", "", fmt.Sprintf("The infra service HTTP API endpoint to use.\n\tExample: localhost:8181 for Exhibitor"))
+	flag.IntVar(&timeout, "timeout", 1, fmt.Sprintf("The infra service timeout, by default 1 second"))
 	flag.StringVarP(&starget, "target", "t", STORAGE_TARGET_TTY, fmt.Sprintf("The storage target to use.\n\tSupported values are %v", startgets))
 	flag.StringVarP(&cred, "credentials", "c", "", fmt.Sprintf("The credentials to use in format STORAGE_TARGET_ENDPOINT,KEY1=VAL1,...KEYn=VALn.\n\tExample: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=..."))
 	flag.StringVarP(&snapshotid, "snapshot", "s", "", fmt.Sprintf("The ID of the snapshot.\n\tExample: 1483193387"))
@@ -104,7 +106,7 @@ func init() {
 	}
 
 	if bfpath, mbrf, err := loadbf(); err != nil {
-		brf = Burryfest{InfraService: isvc, Endpoint: endpoint, StorageTarget: starget, Creds: parsecred()}
+		brf = Burryfest{InfraService: isvc, Endpoint: endpoint, Timeout: timeout, StorageTarget: starget, Creds: parsecred()}
 	} else {
 		brf = mbrf
 		log.WithFields(log.Fields{"func": "init"}).Info(fmt.Sprintf("Using burryfest %s", bfpath))

--- a/manifest.go
+++ b/manifest.go
@@ -18,6 +18,7 @@ import (
 type Burryfest struct {
 	InfraService  string      `json:"svc"`
 	Endpoint      string      `json:"svc-endpoint"`
+	Timeout       int         `json:"timeout"`
 	StorageTarget string      `json:"target"`
 	Creds         Credentials `json:"credentials"`
 }

--- a/zk.go
+++ b/zk.go
@@ -17,7 +17,7 @@ func backupZK() bool {
 		return false
 	}
 	zks := []string{brf.Endpoint}
-	zkconn, _, _ = zk.Connect(zks, time.Second)
+	zkconn, _, _ = zk.Connect(zks, time.Duration(brf.Timeout) * time.Second)
 	// use the ZK API to visit each node and store
 	// the values in the local filesystem:
 	visitZK("/", reapsimple)
@@ -72,7 +72,7 @@ func restoreZK() bool {
 			_ = os.RemoveAll(s)
 		}()
 		zks := []string{brf.Endpoint}
-		zkconn, _, _ = zk.Connect(zks, time.Second)
+		zkconn, _, _ = zk.Connect(zks, time.Duration(brf.Timeout) * time.Second)
 		zkconn.SetLogger(log.StandardLogger())
 		// walk the snapshot directory and use the ZK API to
 		// restore znodes from the local filesystem - note that


### PR DESCRIPTION
By default the infra timeout is 1 second but now you can configure it with the `--timeout=x` flag. This is util for big etcd databases.