### PR TITLE
feat: support non ssl s3 remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,13 +75,13 @@ Arguments:
         The manifest file captures the current command line parameters for re-use in subsequent operations.
   -c, --credentials string
         The credentials to use in format STORAGE_TARGET_ENDPOINT,KEY1=VAL1,...KEYn=VALn.
-        Example: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=...,BUCKET=...,PREFIX=...
+        Example: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=...,BUCKET=...,PREFIX=...,SSL=...
   -e, --endpoint string
         The infra service HTTP API endpoint to use.
         Example: localhost:8181 for Exhibitor
   -i, --isvc string
         The type of infra service to back up or restore.
-        Supported values are [etcd zk] (default "zk")
+        Supported values are [etcd zk consul] (default "zk")
   -o, --operation string
         The operation to carry out.
         Supported values are [backup restore] (default "backup")
@@ -90,7 +90,8 @@ Arguments:
         Example: 1483193387
   -t, --target string
         The storage target to use.
-        Supported values are [local minio s3 tty] (default "tty")
+        Supported values are [local minio s3 tty local] (default "tty")
+      --timeout=1: The infra service timeout, by default 1 second
   -v, --version
         Display version information and exit.
 ```

--- a/main.go
+++ b/main.go
@@ -80,7 +80,7 @@ func init() {
 	flag.StringVarP(&endpoint, "endpoint", "e", "", fmt.Sprintf("The infra service HTTP API endpoint to use.\n\tExample: localhost:8181 for Exhibitor"))
 	flag.IntVar(&timeout, "timeout", 1, fmt.Sprintf("The infra service timeout, by default 1 second"))
 	flag.StringVarP(&starget, "target", "t", STORAGE_TARGET_TTY, fmt.Sprintf("The storage target to use.\n\tSupported values are %v", startgets))
-	flag.StringVarP(&cred, "credentials", "c", "", fmt.Sprintf("The credentials to use in format STORAGE_TARGET_ENDPOINT,KEY1=VAL1,...KEYn=VALn.\n\tExample: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=..."))
+	flag.StringVarP(&cred, "credentials", "c", "", fmt.Sprintf("The credentials to use in format STORAGE_TARGET_ENDPOINT,KEY1=VAL1,...KEYn=VALn.\n\tExample: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=...,BUCKET=...,PREFIX=...,SSL=..."))
 	flag.StringVarP(&snapshotid, "snapshot", "s", "", fmt.Sprintf("The ID of the snapshot.\n\tExample: 1483193387"))
 
 	flag.Usage = func() {

--- a/manifest.go
+++ b/manifest.go
@@ -54,6 +54,7 @@ type S3Config struct {
 	SecretAccessKey string
 	Bucket          string
 	Prefix          string
+	SSL             bool
 }
 
 // parsecred parses the cred string in the form:
@@ -83,6 +84,7 @@ func parsecred() Credentials {
 // extractS3config tries to extract AWS access key and secret
 // from an already parsed cred string
 func extractS3config() (s3Config S3Config) {
+	s3Config.SSL = true
 	for _, p := range brf.Creds.Params {
 		if p.Key == "ACCESS_KEY_ID" {
 			s3Config.AccessKeyId = p.Value
@@ -95,6 +97,13 @@ func extractS3config() (s3Config S3Config) {
 		}
 		if p.Key == "PREFIX" {
 			s3Config.Prefix = p.Value
+		}
+		if p.Key == "SSL" {
+			var err error
+			s3Config.SSL, err = strconv.ParseBool(p.Value)
+			if err != nil {
+				log.Fatal("s3 config parse: ssl:", err)
+			}
 		}
 	}
 	return s3Config

--- a/remotes.go
+++ b/remotes.go
@@ -32,7 +32,6 @@ func toremoteS3(localarch string) {
 	}()
 	endpoint := brf.Creds.StorageTargetEndpoint
 	s3Config := extractS3config()
-	useSSL := true
 	_, f := filepath.Split(localarch)
 	if s3Config.Bucket == "" {
 		s3Config.Bucket = brf.InfraService + "-backup"
@@ -44,7 +43,7 @@ func toremoteS3(localarch string) {
 
 	log.WithFields(log.Fields{"func": "toremoteS3"}).Debug(fmt.Sprintf("Trying to back up to %s/%s in S3 compatible remote storage", s3Config.Bucket, object))
 	mcOpts := minio.Options{}
-	mcOpts.Secure = useSSL
+	mcOpts.Secure = s3Config.SSL
 	if s3Config.AccessKeyId == "" && s3Config.SecretAccessKey == "" {
 		iamCred := credentials.NewIAM("")
 		mcOpts.Creds = iamCred
@@ -93,7 +92,6 @@ func fromremoteS3() string {
 	localarch := filepath.Join(cwd, based+".zip")
 	endpoint := brf.Creds.StorageTargetEndpoint
 	s3Config := extractS3config()
-	useSSL := true
 	if s3Config.Bucket == "" {
 		s3Config.Bucket = brf.InfraService + "-backup"
 	}
@@ -104,7 +102,7 @@ func fromremoteS3() string {
 
 	log.WithFields(log.Fields{"func": "fromremoteS3"}).Debug(fmt.Sprintf("Trying to retrieve %s/%s from S3 compatible remote storage", s3Config.Bucket, object))
 	mcOpts := minio.Options{}
-	mcOpts.Secure = useSSL
+	mcOpts.Secure = s3Config.SSL
 	if s3Config.AccessKeyId == "" && s3Config.SecretAccessKey == "" {
 		iamCred := credentials.NewIAM("")
 		mcOpts.Creds = iamCred


### PR DESCRIPTION
This PR allows burry to connect non ssl S3 remotes like a Minio instance as a sidecar in the same pod.