### PR TITLE
fix: split s3 config by the first delimiter until string end

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -69,9 +69,10 @@ func parsecred() Credentials {
 	params := []CredParams{}
 	// 2nd to end are cred params in key-value format:
 	for _, p := range raw[1:] {
+		pair := strings.SplitN(p, "=", 2)
 		p := CredParams{
-			Key:   strings.Split(p, "=")[0],
-			Value: strings.Split(p, "=")[1],
+			Key:   pair[0],
+			Value: pair[1],
 		}
 		params = append(params, p)
 	}


### PR DESCRIPTION
This PR fix S3 credentials parsing when a pair use an extended charset from AWS official (1). This apply to  an scenario when pointing burry to a Minio instance acting as a gateway to Azure Blob Storage, which uses base64 encoding for secret key.

(1): https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys