### PR TITLE
Possible fix for Issue  17 - Unable to restore Zookeeper

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Arguments:
   -e, --endpoint string
         The infra service HTTP API endpoint to use.
         Example: localhost:8181 for Exhibitor
+  -f, --forget boolean 
+        Forget existing data
   -i, --isvc string
         The type of infra service to back up or restore.
         Supported values are [etcd zk consul] (default "zk")

--- a/consul.go
+++ b/consul.go
@@ -102,7 +102,9 @@ func visitCONSULReverse(path string, f os.FileInfo, err error) error {
 				log.WithFields(log.Fields{"func": "visitCONSULReverse"}).Debug(fmt.Sprintf("Attempting to insert %s as leaf key", key))
 				if c, cerr := readc(cfile); cerr != nil {
 					log.WithFields(log.Fields{"func": "visitCONSULReverse"}).Error(fmt.Sprintf("%s", cerr))
-					return cerr
+					if !forget {
+						return cerr
+					}
 				} else {
 					if node, _, eerr := ckv.Get(key, &qopts); eerr != nil {
 						log.WithFields(log.Fields{"func": "visitCONSULReverse"}).Error(fmt.Sprintf("%s", eerr))

--- a/etcd.go
+++ b/etcd.go
@@ -106,7 +106,9 @@ func visitETCDReverse(path string, f os.FileInfo, err error) error {
 				log.WithFields(log.Fields{"func": "visitETCDReverse"}).Debug(fmt.Sprintf("Attempting to insert %s as leaf key", key))
 				if c, cerr := readc(cfile); cerr != nil {
 					log.WithFields(log.Fields{"func": "visitETCDReverse"}).Error(fmt.Sprintf("%s", cerr))
-					return cerr
+					if !forget {
+						return cerr
+					}
 				} else {
 					if _, kerr := kapi.Set(context.Background(), key, string(c), &etcd.SetOptions{Dir: false, PrevExist: etcd.PrevNoExist}); kerr == nil {
 						log.WithFields(log.Fields{"func": "visitETCDReverse"}).Info(fmt.Sprintf("Restored %s", key))

--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ var (
 	snapshotid string
 	// number of restored items (znodes or keys):
 	numrestored int
+	// Forget existing data
+	forget bool
 )
 
 // reap function types take a node path
@@ -82,6 +84,7 @@ func init() {
 	flag.StringVarP(&starget, "target", "t", STORAGE_TARGET_TTY, fmt.Sprintf("The storage target to use.\n\tSupported values are %v", startgets))
 	flag.StringVarP(&cred, "credentials", "c", "", fmt.Sprintf("The credentials to use in format STORAGE_TARGET_ENDPOINT,KEY1=VAL1,...KEYn=VALn.\n\tExample: s3.amazonaws.com,ACCESS_KEY_ID=...,SECRET_ACCESS_KEY=...,BUCKET=...,PREFIX=...,SSL=..."))
 	flag.StringVarP(&snapshotid, "snapshot", "s", "", fmt.Sprintf("The ID of the snapshot.\n\tExample: 1483193387"))
+	flag.BoolVarP(&forget, "forget", "f", true, fmt.Sprintf("Forget existing data "))
 
 	flag.Usage = func() {
 		fmt.Printf("Usage: burry [args]\n\n")

--- a/zk.go
+++ b/zk.go
@@ -109,7 +109,9 @@ func visitZKReverse(path string, f os.FileInfo, err error) error {
 						log.WithFields(log.Fields{"func": "visitZKReverse"}).Debug(fmt.Sprintf("Attempting to insert %s as leaf znode", znode))
 						if c, cerr := readc(cfile); cerr != nil {
 							log.WithFields(log.Fields{"func": "visitZKReverse"}).Error(fmt.Sprintf("%s", cerr))
-							return cerr
+							if !forget {
+								return cerr
+							}
 						} else {
 							if _, zerr := zkconn.Create(znode, c, 0, zk.WorldACL(zk.PermAll)); zerr != nil {
 								log.WithFields(log.Fields{"func": "visitZKReverse"}).Error(fmt.Sprintf("%s", zerr))


### PR DESCRIPTION
Possible fix for #17  - Unable to restore Zookeeper.
I used the flag --forget shorthand -f, because the "i" shorthand is used by --isvc flag.